### PR TITLE
Make new and lost spans more visible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.33"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b24b79b7a07f10209f19e683ca1e289d80b1e76ffa8c2b779718566a083679"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2262,9 +2262,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,8 @@ impl InvocationTimeouts {
         while let Some((uuid, duration)) = self.timeout_receiver.recv().await {
             let pool = self.pool.clone();
             tokio::spawn(async move {
-                let deadline = time::Instant::now() + duration;
-                tokio::time::sleep_until(deadline.into_inner().into()).await;
+                let deadline = std::time::Instant::now() + duration;
+                tokio::time::sleep_until(deadline.into()).await;
                 match Self::on_deadline(pool, uuid).await {
                     Ok(()) => {}
                     Err(error) => {
@@ -648,7 +648,7 @@ pub struct InvocationCancelRequest {
 async fn insert_commit(tx: &mut Tx, commit: &NewCommit) -> Result<()> {
     sqlx::query("INSERT OR IGNORE INTO commits (sha1, date, message) VALUES (?, ?, ?)")
         .bind(&commit.sha1)
-        .bind(&commit.commit_date.format(&Iso8601::DEFAULT).unwrap())
+        .bind(commit.commit_date.format(&Iso8601::DEFAULT).unwrap())
         .bind(&commit.message)
         .execute(&mut *tx)
         .await

--- a/templates/span_change.html
+++ b/templates/span_change.html
@@ -19,11 +19,13 @@
 {% when Change::New with { stats } %}
 {% let sha1 = target_commit_sha1.clone() %}
 {% let commit_short = "This commit" %}
+{% let outcome = "danger" %}
 {% include "span_change_no_baseline.html" %}
 
 {% when Change::Lost with { stats } %}
 {% let sha1 = comparison.baseline_commit_sha1.clone() %}
 {% let commit_short = "Baseline" %}
+{% let outcome = "success" %}
 {% include "span_change_no_baseline.html" %}
 
 {% endmatch %}

--- a/templates/span_change_no_baseline.html
+++ b/templates/span_change_no_baseline.html
@@ -33,7 +33,8 @@
         <tr>
             <th><abbr title="{{commit_short}} ({{sha1}})">{{sha1|commit_link(commit_short)|safe}}</abbr></th>
             <th>{{stats.mean_self_time|to_ns}} (±{{stats.stddev_self_time|to_ns}})</th>
-            <th>{{stats.mean_time|to_ns}} (±{{stats.stddev_self_time|to_ns}})</th>
+            <th class="has-text-{{outcome}} has-text-weight-semibold">{{stats.mean_time|to_ns}}
+                (±{{stats.stddev_self_time|to_ns}})</th>
             <th>{{stats.mean_call_count}} (±{{stats.stddev_call_count}})</th>
         </tr>
     </tbody>

--- a/templates/view_spans_comparison.html
+++ b/templates/view_spans_comparison.html
@@ -18,6 +18,14 @@
 <section class="section">
     <h2 class="title is-2">Improvements</h2>
 
+    {% for span_change in comparison.olds %}
+    <div class="block">
+        {% let span = span_change.span.clone() %}
+        {% let change = span_change.change %}
+        {% include "span_change.html" %}
+    </div>
+    {% endfor %}
+
     {% for span_change in comparison.improvements.iter().rev() %}
     <div class="block">
         {% let span = span_change.span.clone() %}
@@ -28,6 +36,14 @@
 </section>
 <section class="section">
     <h2 class="title is-2">Regressions</h2>
+
+    {% for span_change in comparison.news %}
+    <div class="block">
+        {% let span = span_change.span.clone() %}
+        {% let change = span_change.change %}
+        {% include "span_change.html" %}
+    </div>
+    {% endfor %}
 
     {% for span_change in comparison.regressions.iter().rev() %}
     <div class="block">
@@ -52,28 +68,6 @@
     <h2 class="title is-2">Unstable</h2>
 
     {% for span_change in comparison.unstables %}
-    <div class="block">
-        {% let span = span_change.span.clone() %}
-        {% let change = span_change.change %}
-        {% include "span_change.html" %}
-    </div>
-    {% endfor %}
-</section>
-<section class="section">
-    <h2 class="title is-2">New</h2>
-
-    {% for span_change in comparison.news %}
-    <div class="block">
-        {% let span = span_change.span.clone() %}
-        {% let change = span_change.change %}
-        {% include "span_change.html" %}
-    </div>
-    {% endfor %}
-</section>
-<section class="section">
-    <h2 class="title is-2">Lost</h2>
-
-    {% for span_change in comparison.olds %}
     <div class="block">
         {% let span = span_change.span.clone() %}
         {% let change = span_change.change %}

--- a/templates/view_spans_no_comparison.html
+++ b/templates/view_spans_no_comparison.html
@@ -13,6 +13,7 @@
         {% let stats = stat %}
         {% let sha1 = target_commit_sha1.clone() %}
         {% let commit_short = "This commit" %}
+        {% let outcome = "info" %}
         {% include "span_change_no_baseline.html" %}
     </div>
     {% endfor %}


### PR DESCRIPTION
Before this PR, new and lost spans are displayed in a dedicated category at the bottom of the page.

This has the effect that we sometimes miss them, making benchmark interpretation more difficult than needs be.

This PR integrates the new and lost spans at the top of the (respectively) regressions and improvements categories.

As a new span represents time spent that wasn't previously, it appears in the regressions category. Symmetric reasoning applies for lost spans.