### PR TITLE
Allow changing commits from the interface

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -39,3 +39,7 @@
         transform: rotate(360deg);
     }
 }
+
+.input {
+    color: #333;
+}

--- a/src/view.rs
+++ b/src/view.rs
@@ -599,7 +599,11 @@ async fn view_spans(
 
     let baseline_commit = 'commit: {
         if let Some(baseline_commit) = baseline_commit {
-            break 'commit Some(baseline_commit);
+            if baseline_commit.is_empty() {
+                break 'commit None;
+            } else {
+                break 'commit Some(baseline_commit);
+            }
         }
         if let Some(baseline_tag) = baseline_tag.as_deref() {
             if let Some(commit) = commit_for_tag(&mut tx, baseline_tag, &workload_name).await? {

--- a/templates/commit_form.html
+++ b/templates/commit_form.html
@@ -65,7 +65,7 @@
 
             <div class="field">
                 <div class="control">
-                    <button class="button is-link">Submit</button>
+                    <button class="button is-link">Change</button>
                 </div>
             </div>
         </form>

--- a/templates/commit_form.html
+++ b/templates/commit_form.html
@@ -1,0 +1,73 @@
+<div class="block">
+    <details>
+        <summary class="button is-small">Change commits or workload</summary>
+        <br />
+        <br />
+        <form class="block">
+            <div class="field">
+                <label class="label">Workload</label>
+                <div class="control">
+                    <input class="input" name="workload_name" type="text" list="workload_name_list"
+                        value="{{workload_name}}" required autocomplete="off" />
+                    <datalist id="workload_name_list">
+                        <option value="{{workload_name}}"></option>
+                        {% for workload_name in latest_workloads %}
+                        <option value="{{workload_name}}"></option>
+                        {% endfor %}
+                    </datalist>
+                </div>
+                <p class="help">Name of the workload you want to evaluate</p>
+            </div>
+
+
+            <div class="field">
+                <label class="label">Target commit SHA1</label>
+                <div class="control">
+                    <input class="input" name="commit_sha1" type="text" value="{{target_commit_sha1}}"
+                        autocomplete="off" list="commit_sha1_list" required />
+                    <datalist id="commit_sha1_list">
+                        <option value="{{target_commit_sha1}}">Current target commit</option>
+                        {% match baseline_commit %}
+                        {% when Some with (baseline_commit) %}
+                        <option value="{{baseline_commit}}">Switch to baseline commit</option>
+                        {% when None %}
+                        {% endmatch %}
+                        {% for (commit_sha1, commit_message) in latest_commits %}
+                        <option value="{{commit_sha1}}">{{commit_sha1|commit|safe}} - {{ commit_message|truncate(180) }}
+                        </option>
+                        {% endfor %}
+                    </datalist>
+                </div>
+                <p class="help">Commit you want to evaluate</p>
+            </div>
+
+            <div class="field">
+                <label class="label">Baseline commit SHA1</label>
+                <div class="control">
+                    <input class="input" name="baseline_commit" type="text" list="baseline_commit_list" {% match
+                        baseline_commit %} {% when Some with (baseline_commit) %} value="{{baseline_commit}}" {% when
+                        None %}{% endmatch %} autocomplete="off" />
+                    <datalist id="baseline_commit_list">
+                        {% match baseline_commit %}
+                        {% when Some with (baseline_commit) %}
+                        <option value="{{baseline_commit}}">Current baseline commit</option>
+                        {% when None %}
+                        {% endmatch %}
+                        <option value="{{target_commit_sha1}}">Switch to target commit</option>
+                        {% for (commit_sha1, commit_message) in latest_commits %}
+                        <option value="{{commit_sha1}}">{{commit_sha1|commit|safe}} - {{ commit_message|truncate(180) }}
+                        </option>
+                        {% endfor %}
+                    </datalist>
+                </div>
+                <p class="help">Improvements and regressions are reported relative to this commit</p>
+            </div>
+
+            <div class="field">
+                <div class="control">
+                    <button class="button is-link">Submit</button>
+                </div>
+            </div>
+        </form>
+    </details>
+</div>

--- a/templates/commit_subtitle.html
+++ b/templates/commit_subtitle.html
@@ -25,9 +25,9 @@ on {{branch|branch|safe}}
 {% macro baseline_str %}
 {% match baseline_branch %}
 {% when Some with (branch) %}
-branch {{branch|branch|safe}} (on {{baseline_commit|commit|safe}}) {% call baseline_tag_str() %}
+branch {{branch|branch|safe}} (on {{some_baseline_commit|commit|safe}}) {% call baseline_tag_str() %}
 {% when None %}
-{{baseline_commit|commit|safe}} {% call baseline_tag_str() %}
+{{some_baseline_commit|commit|safe}} {% call baseline_tag_str() %}
 {% endmatch %}
 {% endmacro %}
 
@@ -35,8 +35,8 @@ branch {{branch|branch|safe}} (on {{baseline_commit|commit|safe}}) {% call basel
     to {% call baseline_str() %}
 </h2>
 
-
 <div class="block">
     <a class="button is-link" target="_blank"
-        href="https://github.com/meilisearch/meilisearch/compare/{{baseline_commit}}..{{target_commit}}">Diff</a>
+        href="https://github.com/meilisearch/meilisearch/compare/{{some_baseline_commit}}..{{target_commit}}">GitHub
+        Diff</a>
 </div>

--- a/templates/view_span_comparison.html
+++ b/templates/view_span_comparison.html
@@ -1,6 +1,6 @@
 <h1 class="title">Span {{span}} in <code>{{workload_name}}</code></h1>
 
-{% let baseline_commit = baseline.clone() %}
+{% let some_baseline_commit = baseline.clone() %}
 {% let target_commit = target_commit_sha1.clone() %}
 
 {% include "commit_subtitle.html" %}

--- a/templates/view_spans_comparison.html
+++ b/templates/view_spans_comparison.html
@@ -4,6 +4,7 @@
 {% let some_baseline_commit = comparison.baseline_commit_sha1.clone() %}
 {% include "commit_subtitle.html" %}
 
+{% include "commit_form.html" %}
 
 {% match comparison.total_time %}
 {% when Some with (span_change) %}

--- a/templates/view_spans_comparison.html
+++ b/templates/view_spans_comparison.html
@@ -1,8 +1,7 @@
 <h1 class="title">Workload {{workload_name}}</h1>
 
 {% let target_commit = target_commit_sha1.clone() %}
-{% let baseline_commit = comparison.baseline_commit_sha1.clone() %}
-
+{% let some_baseline_commit = comparison.baseline_commit_sha1.clone() %}
 {% include "commit_subtitle.html" %}
 
 

--- a/templates/view_spans_no_comparison.html
+++ b/templates/view_spans_no_comparison.html
@@ -6,6 +6,9 @@
 {% when None %}
 <h2 class="subtitle">{{target_commit_sha1|commit|safe}}</h2>
 {% endmatch %}
+
+{% include "commit_form.html" %}
+
 <section class="section">
 
     {% for (span, stat) in stats.iter() %}


### PR DESCRIPTION
Adds a new part of the interface that allows picking which commits to compare.

<details>
<summary>New added button</summary>

<img width="1202" alt="Capture d’écran 2025-03-20 à 16 34 13" src="https://github.com/user-attachments/assets/0c9dd8bd-2b81-4da1-8979-59c6f13e65e0" />


</details>


<details>
<summary>Clicking it reveals the added interface</summary>

<img width="1202" alt="Capture d’écran 2025-03-20 à 16 34 08" src="https://github.com/user-attachments/assets/4ed7cf2b-23a8-4f98-86d3-405909589d9c" />

</details>


<details>
<summary>You can change the workload with autocompletion from recent workloads</summary>

<img width="1202" alt="Capture d’écran 2025-03-20 à 16 32 46" src="https://github.com/user-attachments/assets/119fa68c-4b43-4dca-b484-938f5593394c" />

</details>

<details>
<summary>You can swap the commits</summary>

<img width="1202" alt="Capture d’écran 2025-03-20 à 16 32 52" src="https://github.com/user-attachments/assets/1a220a6f-24d2-41ae-a6fd-3d943c78222d" />

</details>

<details>
<summary>Or use autocompletion for recent commits</summary>

<img width="1202" alt="Capture d’écran 2025-03-20 à 16 32 57" src="https://github.com/user-attachments/assets/da117db2-b402-4492-af3f-131102f62dc3" />

</details>